### PR TITLE
clang-format: link to .clang-format

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,6 +8,7 @@
     <linkfile src="Dockerfile" dest="Dockerfile"/>
     <linkfile src="Makefile" dest="Makefile"/>
     <linkfile src="run-clang-format.sh" dest="run-clang-format.sh"/>
+    <linkfile src=".clang-format" dest=".clang-format"/>
     <linkfile src="lua" dest="lua"/>
   </project>
 


### PR DESCRIPTION
Seems to be missing. The .clang-format file must be in the same location as the run-clang-format.sh script